### PR TITLE
feat: snapshotpod support label select

### DIFF
--- a/api/v1alpha1/snapshotpod_types.go
+++ b/api/v1alpha1/snapshotpod_types.go
@@ -23,10 +23,13 @@ import (
 type TargetPod struct {
 	// Name of the target pod, one of name or selector is required.
 	Name string `json:"name,omitempty"`
-	// Selector of the target pod(labels), one of name or selector is required.
-	// When specify selector, the snapshot-pod will snapshot the first pod that match the selector(name sorted).
-	// not implemented,
-	// Selector map[string]string `json:"selector,omitempty"`
+	// Selector of the target pod (labels). One of name or selector is required.
+	// Matching logic:
+	// 1. If both name and selector are specified, only name will be used for matching, and selector will be ignored.
+	// 2. If name is not specified, selector will be used to match pods.
+	//    - Only one pod can be matched by selector.
+	//    - If multiple pods are matched, an error will be raised.
+	Selector map[string]string `json:"selector,omitempty"`
 	// Containers to snapshot, if not specified, snapshot all containers in the pod.
 	Containers []string `json:"containers,omitempty"`
 }

--- a/config/crd/bases/snapshot-pod.baizeai.io_snapshotpods.yaml
+++ b/config/crd/bases/snapshot-pod.baizeai.io_snapshotpods.yaml
@@ -107,12 +107,8 @@ spec:
                 description: Target pod to snapshot.
                 properties:
                   containers:
-                    description: |-
-                      Selector of the target pod(labels), one of name or selector is required.
-                      When specify selector, the snapshot-pod will snapshot the first pod that match the selector(name sorted).
-                      not implemented,
-                      Selector map[string]string `json:"selector,omitempty"`
-                      Containers to snapshot, if not specified, snapshot all containers in the pod.
+                    description: Containers to snapshot, if not specified, snapshot
+                      all containers in the pod.
                     items:
                       type: string
                     type: array
@@ -120,6 +116,17 @@ spec:
                     description: Name of the target pod, one of name or selector is
                       required.
                     type: string
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Selector of the target pod (labels). One of name or selector is required.
+                      Matching logic:
+                      1. If both name and selector are specified, only name will be used for matching, and selector will be ignored.
+                      2. If name is not specified, selector will be used to match pods.
+                         - Only one pod can be matched by selector.
+                         - If multiple pods are matched, an error will be raised.
+                    type: object
                 type: object
               triggerRound:
                 format: int32

--- a/manifests/snapshot-pod/templates/snapshot-pod.baizeai.io_snapshotpods.yaml
+++ b/manifests/snapshot-pod/templates/snapshot-pod.baizeai.io_snapshotpods.yaml
@@ -107,12 +107,8 @@ spec:
                 description: Target pod to snapshot.
                 properties:
                   containers:
-                    description: |-
-                      Selector of the target pod(labels), one of name or selector is required.
-                      When specify selector, the snapshot-pod will snapshot the first pod that match the selector(name sorted).
-                      not implemented,
-                      Selector map[string]string `json:"selector,omitempty"`
-                      Containers to snapshot, if not specified, snapshot all containers in the pod.
+                    description: Containers to snapshot, if not specified, snapshot
+                      all containers in the pod.
                     items:
                       type: string
                     type: array
@@ -120,6 +116,17 @@ spec:
                     description: Name of the target pod, one of name or selector is
                       required.
                     type: string
+                  selector:
+                    additionalProperties:
+                      type: string
+                    description: |-
+                      Selector of the target pod (labels). One of name or selector is required.
+                      Matching logic:
+                      1. If both name and selector are specified, only name will be used for matching, and selector will be ignored.
+                      2. If name is not specified, selector will be used to match pods.
+                         - Only one pod can be matched by selector.
+                         - If multiple pods are matched, an error will be raised.
+                    type: object
                 type: object
               triggerRound:
                 format: int32


### PR DESCRIPTION
The target name is tightly bound to the pod's name and is only applicable for StatefulSets . This is because the pod name remains unchanged after a restart in StatefulSets. However, in Deployments, the pod name changes with every restart. Therefore, a label selector mechanism is introduced to capture the pod in such scenarios.

1. set deployment label 
![image](https://github.com/user-attachments/assets/c098158f-40cd-4028-a219-4bfb138009c9)
2. apply SnapshotPod and set label selector
 ![image](https://github.com/user-attachments/assets/27cf262f-624a-460b-aba0-dca0039f8392)

3. Task complete
![image](https://github.com/user-attachments/assets/6bac970b-9075-4903-9deb-59a83fd3c358)

4. image pushed
![image](https://github.com/user-attachments/assets/c1484c4a-c417-48e7-beb0-386a67ec2fde)

5. restart deployment,
![image](https://github.com/user-attachments/assets/fbad9889-ee08-4558-bcf5-b6d8c38ac845)
