### PR TITLE
fix: docker commit failed

### DIFF
--- a/internal/controller/runtime/docker_compatible.go
+++ b/internal/controller/runtime/docker_compatible.go
@@ -24,13 +24,14 @@ func NewDockerCompatibleRuntime(cmd string, globalArgs ...string) Runtime {
 }
 
 func (d *dockerCompatibleRuntime) Commit(ctx context.Context, containerID, image string, pause bool, message, author string) error {
-	args := []string{"commit", containerID, image, fmt.Sprintf("--pause=%v", pause)}
+	args := []string{"commit", fmt.Sprintf("--pause=%v", pause)}
 	if message != "" {
 		args = append(args, "--message", message)
 	}
 	if author != "" {
 		args = append(args, "--author", author)
 	}
+	args = append(args, containerID, image)
 	if err := d.execCommand(ctx, args, nil); err != nil {
 		return fmt.Errorf("commit image: %s", err)
 	}


### PR DESCRIPTION
related issue: #51  
put all flags before parameters   
nerdctl: 
```
[root@mcamel-e2e-master ~]# nerdctl commit --pause=true --author=mabing --message='fix #51' fe2d021d5ac3 release-ci.daocloud.io/aichat/baize-notebook:snapped-1755844726
-de262be2
WARN[0000] Image lacks label "nerdctl/platform", assuming the platform to be "linux/amd64"
sha256:2ce4d119dbda365c3640dedf8f80ea603a69f6bc04a257a657c44e3b78c9b1ef
```
docker:
```
❯ docker commit --pause=true --author=mabing --message='fix #51' 7a33bff1f330 release-ci.daocloud.io/aichat/baize-notebook:snapped-1755844726-de262be2
sha256:988af946e960a4c145e0fcd49cffbe286eccf6405fbb85a9ebfad3fa5491c980
```


I tested, it looks all good:
```

I0826 03:11:00.863495       1 docker_compatible.go:97] execCommand: docker [commit --pause=true db762ec987e55eeaeaf85757edd80e38b396df7ea278614206f2b0f4f1567c0b release-ci.daocloud.io/aichat/baize-notebook:snapped-1756177850-f096e326], out: sha256:36cae6072a514f72aea1d75987f1409077fd80ef0d33a0fd159fae1343989ffd
, errOut: , err: <nil>
I0826 03:11:00.911728       1 docker_compatible.go:97] execCommand: docker [image inspect release-ci.daocloud.io/aichat/baize-notebook:snapped-1756177850-f096e326], out: [
    {
        "Id": "sha256:36cae6072a514f72aea1d75987f1409077fd80ef0d33a0fd159fae1343989ffd",
        "RepoTags": [
            "release-ci.daocloud.io/aichat/baize-notebook:snapped-1756177850-f096e326"
        ],
        "RepoDigests": [],
        "Parent": "sha256:adc6644c551a513a09775794bb96d6e120f015a298dd7f131a5bf2812125ccbc",
        "Comment": "",
        "Created": "2025-08-26T03:11:00.824088376Z",
        "DockerVersion": "28.3.3",
        "Author": "",
        "Architecture": "amd64",
        "Os": "linux",
        "Size": 3428139582,
        "GraphDriver": {
            "Data": {
                "LowerDir": "/var/lib/docker/overlay2/5e047e52efb947ef4c3f0c7efa2f01b5174c3679d1dac56e876b9abf51c231b2/diff:/var/lib/docker/overlay2/8af970ec7417de14111b418b537c0ecfd52cc251883de8685a6f07f995898013/diff:/var/lib/docker/overlay2/53fb0527d553fad6f6f79feefb6883bc85b98d17c04864064e1421a773c97f21/diff:/var/lib/docker/overlay2/90b7c20d091b84a2d8484f75361ef451431e3dd981d16e3ec59942c287528ba0/diff:/var/lib/docker/overlay2/c95a897814cb9d57cc52aa42a479dda598231ef68dee4909aa5e0adcb0675a93/diff:/var/lib/docker/overlay2/71a0d220b96c9069e23980b1410863e18834acd6bb27907c844062508a2d2c4e/diff:/var/lib/docker/overlay2/62a9f3d0ed6ec1174a2e4ab4428ed942da7809541ff62863987f6b793b7c0a93/diff:/var/lib/docker/overlay2/4e9b6bfc8631ae46da7e03c3d9de2155e24efbfa5d06a1159baae02b4056d551/diff:/var/lib/docker/overlay2/60f5af7d8849c02a696cdcad199781ee24d914954eb5411c9ddd571da8bd5da9/diff:/var/lib/docker/overlay2/80f1684f7a34bee971dca87121adba8e7ef89370fb57cbbd363bcebce8c4ee73/diff:/var/lib/docker/overlay2/11c4464aeca2581c85f3d81512a88a444f30cd8d43dcc3c8d3777b3c0401ca69/diff:/var/lib/docker/overlay2/08225be1546a11a6fed186b4c1a0ff51b43f86aec3d5e1c436eaae2e5a815dd4/diff:/var/lib/docker/overlay2/08eac07ad85d18c8016dc04aabdd37dd9c48c6cf06eb309f9e614c85392c2ece/diff:/var/lib/docker/overlay2/56a101c0af6a9fe65c7aa3ba64fcbb43688af2f266aa8961c25aa600300d6ac7/diff:/var/lib/docker/overlay2/a69ae3d8389c923c7bedba45ba9b30b89c256e1da85add105591dcfd6bcd7030/diff:/var/lib/docker/overlay2/5b4b2b9d6aedcb0c2a32a29c8c2cc656e95acbba685fab4bcb4e770288bc38a6/diff:/var/lib/docker/overlay2/162b9438b6c0a3c550e080546dfa71c54aa64134781a90a395a31b1fca71f246/diff:/var/lib/docker/overlay2/bba2fc8e2c7d330c615871778cdb3c5fa3fc515737743d73b6ce24dbdba4e60f/diff:/var/lib/docker/overlay2/5b7be8edc44b929fad8a0a34074fd781043d4aa121d5eafea41cd52f959be500/diff:/var/lib/docker/overlay2/23094dea53c4376ed911625229153e23f353ad1af2fd2e40c8c8a55db9b2fcd0/diff:/var/lib/docker/overlay2/44667e836a887cfcd6f96efe5f533c744000d1265d7d732a5dec55c65b7f0d0f/diff:/var/lib/docker/overlay2/c364d1bbf10cc2f200dcb283905d051532c179c158f1d0814cea3de139b990d5/diff:/var/lib/docker/overlay2/5f8c773e68fb9b2c3a7e613c6d85af958c4babfd9d1ae47a1a08846ff03d3e94/diff:/var/lib/docker/overlay2/c4d517c517a5aab335ebbf40f04fc04a28e3d3d06f3040705c58fd29e67472f2/diff:/var/lib/docker/overlay2/0fced3de28b1dad60b2002b361ddaf3ca40178a55dc5c31fa4963fdcb5d89c2f/diff:/var/lib/docker/overlay2/d9f27401d174d97d9309c328ddea8c37d7368e19ce018431fa8f30ba61b97dbc/diff:/var/lib/docker/overlay2/24ac392b07e73928a36a3ebb45e21130575c0be4489055d70ee01e36a7d76659/diff:/var/lib/docker/overlay2/298df78749f7f2f40ffdc3485a4e2046f2e7553cc6920c1fb9581deb0285404a/diff:/var/lib/docker/overlay2/8465ba888f155b559a1afe4d6abc3640381bc25a54d5f452ad2d6b8d3c07d682/diff:/var/lib/docker/overlay2/e534a3cfcb13d8c0e7002ac659d6f29e341491749ebace9bc754d85bfc19b8f2/diff:/var/lib/docker/overlay2/1a19b3cbe7254f5e2c3cc331d8d1aa68d4f13381893bfd859f151ae4618baab4/diff:/var/lib/docker/overlay2/7a261161f58bdd533e78aa4e68d4f9fd04f9ca6d77c8cefbbb463fc3c221e0f7/diff:/var/lib/docker/overlay2/38c97fc661228eadbb3fe3cf0f65d40ddffa18ddeb0c8d098d9b9733eba67f48/diff:/var/lib/docker/overlay2/8f2d9dd544a51893393685710e5247e95f8b2ca5018819d9aeebc830b3853878/diff:/var/lib/docker/overlay2/bc8145534d2622fa8b7d04e11dd09fdb6d9797914928229b29642c21606150bd/diff:/var/lib/docker/overlay2/92b8f54511901e260fefe805d5aac223e155d62f815c1884976b514688a00291/diff:/var/lib/docker/overlay2/e1f74a8ebcdd031ccd1339523becff7971c1685140f6e0ffa6ce852b930142cc/diff:/var/lib/docker/overlay2/6a6d2389567e2ed1d1c59bb7212dbd9c64e535641b7a5a066cfd83d2ec37cd44/diff:/var/lib/docker/overlay2/eb7165b9cdd41ce8538afa64cf800d997b3db00253288859c8790f8bb37c97f4/diff",
                "MergedDir": "/var/lib/docker/overlay2/0f3cf7ffbc41dcffb64b9cef23a14ea3d5aab5e810ffe2d0b88b719a634a658c/merged",
                "UpperDir": "/var/lib/docker/overlay2/0f3cf7ffbc41dcffb64b9cef23a14ea3d5aab5e810ffe2d0b88b719a634a658c/diff",
                "WorkDir": "/var/lib/docker/overlay2/0f3cf7ffbc41dcffb64b9cef23a14ea3d5aab5e810ffe2d0b88b719a634a658c/work"
            },
            "Name": "overlay2"
        },
        "RootFS": {
            "Type": "layers",
            "Layers": [
                "sha256:931b7ff0cb6f494b27d31a4cbec3efe62ac54676add9c7469560302f1541ecaf",
                "sha256:048d77f5d0e81e9e99f37f7eadd00dc7c5aee345ee284f1399255585e5d4fdf8",
                "sha256:8c343de658a6c926b41962560ff9bd456ff846189bd9898d4b7a8949cbb87d0f",
                "sha256:b139b771a6670b1cccca44b2f3770e20bab6515015e2bb0b228fc3262cc2180c",
                "sha256:4e31776d15a94da187ab6cb9bfcb5977f41fcb6163fb31b2d6df513b25fbd451",
                "sha256:e63c814e86dc7fbcc86f7b1be5997c6ec882f4404bac13f21aec9670c6f62a95",
                "sha256:0b6ce260255458a30dc493aef1ad17fb80167f240fcb0a88309b852b883adb0a",
                "sha256:b67fc286cf0162f4aaa36cae645e807501087de0fdc7d03e2232466d060ee18a",
                "sha256:2f16d2faf9918de2c1aded5e55a29da42b04fda758b045b50403671887fa417b",
                "sha256:be4bc107e225ed2d35027d6b7a2dbaa04b3ffcf73020252fc078e82c05a90b82",
                "sha256:49a53217092850c310f6bc08d4e4a0ea7c4685bbb4192d51bc858ae0e2b580b8",
                "sha256:6d6f2e66c598dce69c3a6a34335acd16b7cb121d24b4f7b4841bf1127775f98a",
                "sha256:9bc2ae963bbaa5b1dcc241625c450f618b6f5c0db0495d8f29eb0349807b14ad",
                "sha256:e07f806fd33a76fdd96303f5e07bbccb833e9835c4315ccdeb54807149c32812",
                "sha256:b313f5729b0874502bdb967dcda5ea5217f642a3a9892335d40438989d51366c",
                "sha256:2fcc256d0e2c3a92a9832ed219d91839f33682f791f9c0869756eda67251f130",
                "sha256:9fcf1aaa6291d20a37cb6e40f100e3759a825208ab59d1f53ce8de355ddb34d3",
                "sha256:6dc41e67edf66b1d4c79c231f2d58ed49dbaae6f1a61ceed6361931291bc46da",
                "sha256:e4932670a4cafa5ef21b80591f9c3838abd1d1b91cb120a6c50549dde85518cc",
                "sha256:0792c5b6dfdeb2a28337fcf8ec84cb4bbd038369beef02c3f901d36017b86c24",
                "sha256:089daa7f475c793bd993880b93f8c71e1a6d9af28766c5e9ae1a0306258f9a96",
                "sha256:81bf62d7312569e53db8eef51924a3fbb936ed55b4be98c160d34dae97bdbaf4",
                "sha256:c2c2cbddab0833e07c136493a2a387220992dbd9b6f7af907f905e166d99db12",
                "sha256:c4b0041ab583cf728fcc8285b4f5f6c178c99d209b7b56de81cf5069922d36cd",
                "sha256:e2b0056708c43be2022a3c59b513e8c70d6e912b0e8e356e9b202d4031311892",
                "sha256:c4edf25bff5276e843f7f37f8b61b75dd89db0a5fd1c1d59c033b1f5358134b4",
                "sha256:df32b1b754a1e4f8f6a73af739b295fe6dece1d507a7a6c8bced1438db01a917",
                "sha256:a2bd2ab2ae36bcd6ead245f7df9c86667e737419af1be29874a91d4c2f6f0f85",
                "sha256:14aee8924f85a34049de4f7d7df2082f187ec18a007495811a1a375b63e35a28",
                "sha256:f852756667081543369a34e6896a9f68581e755b0507d00270fe645ddd984e5a",
                "sha256:20fa7b16bf50d60e44c38a80be291c5534c1e83995e2a42e4a23afea748ab8a6",
                "sha256:5876eee782f260f08b13e1cfd32f8c656ef21534528b8bc2eefeda0003f986a0",
                "sha256:3e4ff3e3033e1368c35532aca43c6a380cbbe0fce35fd435e844f05bb6b4f05b",
                "sha256:5619ebf6d87ac95fb4fe92fa380b87874d4903337480202cb0159abefb7f576d",
                "sha256:5c13a29d0f924ee430359d46c7488d34c631bc50ec669e047a90cf59afd71176",
                "sha256:fe22f0d183d578e627130981e1aba579b968d548bfc821dd53c41bcca6b40081",
                "sha256:1d70909daa7c1e26312e7d748fa3794e8909dc2f2e2495ca2323aa5bedf030ed",
                "sha256:b16d81b9c699151dcbf063f28ecd030a1e3de9863a9f7240c786f2234f1e5a85",
                "sha256:a334d6bfa269335351d7d2ce07b3faea6145b40813db233b71ad865ff060a158",
                "sha256:8e5c0691c425e416bbc9d88a7f0f529ea186df6929fef1c251539289c69b42c1"
            ]
        },
        "Metadata": {
            "LastTagTime": "2025-08-26T11:11:00.837142803+08:00"
        },
        "Config": {
            "AttachStderr": false,
            "AttachStdin": false,
            "AttachStdout": false,
            "Cmd": null,
            "Domainname": "",
            "Entrypoint": [
                "/init"
            ],
            "Env": [
                "NB_PREFIX=/baize/proxy/notebooks-jupyter/mabing/default/notebook0822",
                "MABING0821_5744_MYSQL_REPLICAS_PORT=tcp://10.99.64.183:3306",
                "KUBERNETES_SERVICE_HOST=10.96.0.1",
                "MGR0325_PORT_6446_TCP_ADDR=10.96.69.126",
                "MGR0325_PORT_6448_TCP_ADDR=10.96.69.126",
                "KINGBASE_V8R6_SERVICE_HOST=10.99.145.202",
                "MGR0325_SERVICE_PORT_MYSQLX=33060",
                "MABING0821_5744_EXPORTER_SVC_SERVICE_PORT_PROMETHEUS=9125",
                "NOTEBOOK0822_PORT_80_TCP_ADDR=10.103.75.165",
                "MGR0325_SERVICE_PORT_MYSQLX_ALTERNATE=6448",
                "MGR0325_PORT_3306_TCP_ADDR=10.96.69.126",
                "MABING0821_5744_MYSQL_SERVICE_HOST=10.96.164.154",
                "MGR0325_PORT_8443_TCP_PROTO=tcp",
                "MABING0821_5744_EXPORTER_SVC_PORT_9125_TCP=tcp://10.97.152.175:9125",
                "NOTEBOOK0822_SERVICE_PORT_HTTP_NOTEBOOK0822=80",
                "NOTEBOOK0822_PORT_80_TCP_PORT=80",
                "MGR0325_PORT_6449_TCP=tcp://10.96.69.126:6449",
                "MGR0325_PORT_6449_TCP_PROTO=tcp",
                "MGR0325_SERVICE_PORT_MYSQL_ALTERNATE=6446",
                "MABING0821_5744_MYSQL_PORT_3306_TCP_PROTO=tcp",
                "AKHQ_PORT_80_TCP=tcp://10.111.64.47:80",
                "KAFDROP_PORT_9000_TCP=tcp://10.97.30.224:9000",
                "MABING0821_5744_MYSQL_REPLICAS_PORT_3306_TCP_PORT=3306",
                "KUBERNETES_PORT=tcp://10.96.0.1:443",
                "AKHQ_SERVICE_PORT=80",
                "KUBERNETES_PORT_443_TCP_PROTO=tcp",
                "MGR0325_PORT_3306_TCP_PROTO=tcp",
                "MGR0325_PORT_3306_TCP_PORT=3306",
                "MABING0821_5744_MYSQL_SERVICE_PORT=3306",
                "AKHQ_PORT_28081_TCP_PROTO=tcp",
                "KAFDROP_SERVICE_PORT_HTTP=9000",
                "KAFDROP_PORT_9000_TCP_PORT=9000",
                "MGR0325_PORT_8443_TCP=tcp://10.96.69.126:8443",
                "MABING0821_5744_EXPORTER_SVC_SERVICE_PORT=9125",
                "NOTEBOOK0822_SERVICE_PORT=80",
                "MABING0821_5744_MYSQL_REPLICAS_SERVICE_PORT=3306",
                "MABING0821_5744_MYSQL_MASTER_SVC_SERVICE_PORT=3306",
                "MABING0821_5744_MYSQL_PORT_3306_TCP_ADDR=10.96.164.154",
                "AKHQ_PORT_80_TCP_PORT=80",
                "MGR0325_PORT_6450_TCP=tcp://10.96.69.126:6450",
                "AKHQ_PORT_80_TCP_PROTO=tcp",
                "MABING0821_5744_MYSQL_MASTER_PORT_8080_TCP_ADDR=10.111.105.70",
                "MGR0325_PORT_33060_TCP=tcp://10.96.69.126:33060",
                "MGR0325_PORT_33060_TCP_PROTO=tcp",
                "MGR0325_PORT_3306_TCP=tcp://10.96.69.126:3306",
                "KINGBASE_V8R6_SERVICE_PORT_DBPORT=54321",
                "NOTEBOOK0822_PORT_80_TCP=tcp://10.103.75.165:80",
                "MABING0821_5744_MYSQL_MASTER_SERVICE_PORT_SIDECAR_HTTP=8080",
                "MABING0821_5744_MYSQL_REPLICAS_PORT_8080_TCP=tcp://10.99.64.183:8080",
                "MABING0821_5744_MYSQL_PORT=tcp://10.96.164.154:3306",
                "MABING0821_5744_MYSQL_PORT_3306_TCP_PORT=3306",
                "KINGBASE_V8R6_PORT=tcp://10.99.145.202:54321",
                "MABING0821_5744_MYSQL_MASTER_SERVICE_PORT=3306",
                "KUBERNETES_PORT_443_TCP_ADDR=10.96.0.1",
                "MGR0325_SERVICE_PORT_MYSQL_RW_SPLIT=6450",
                "MABING0821_5744_MYSQL_REPLICAS_PORT_8080_TCP_ADDR=10.99.64.183",
                "KUBERNETES_PORT_443_TCP_PORT=443",
                "MGR0325_PORT_6449_TCP_PORT=6449",
                "MABING0821_5744_MYSQL_MASTER_SVC_PORT=tcp://10.104.149.173:3306",
                "AKHQ_PORT_28081_TCP=tcp://10.111.64.47:28081",
                "MABING0821_5744_MYSQL_MASTER_PORT_3306_TCP_ADDR=10.111.105.70",
                "MGR0325_PORT_33060_TCP_ADDR=10.96.69.126",
                "MGR0325_PORT_6448_TCP_PROTO=tcp",
                "MGR0325_PORT_6446_TCP_PROTO=tcp",
                "MGR0325_PORT_6449_TCP_ADDR=10.96.69.126",
                "AKHQ_SERVICE_HOST=10.111.64.47",
                "AKHQ_PORT_28081_TCP_ADDR=10.111.64.47",
                "MABING0821_5744_MYSQL_REPLICAS_PORT_3306_TCP_ADDR=10.99.64.183",
                "MABING0821_5744_MYSQL_REPLICAS_PORT_8080_TCP_PROTO=tcp",
                "KINGBASE_V8R6_PORT_54321_TCP_ADDR=10.99.145.202",
                "KUBERNETES_SERVICE_PORT=443",
                "MABING0821_5744_EXPORTER_SVC_PORT_9125_TCP_PORT=9125",
                "MABING0821_5744_MYSQL_MASTER_SVC_SERVICE_HOST=10.104.149.173",
                "MABING0821_5744_MYSQL_MASTER_SVC_PORT_3306_TCP_PORT=3306",
                "NOTEBOOK0822_PORT_80_TCP_PROTO=tcp",
                "MABING0821_5744_MYSQL_REPLICAS_SERVICE_PORT_SIDECAR_HTTP=8080",
                "MGR0325_PORT_6450_TCP_PORT=6450",
                "MGR0325_PORT_6450_TCP_ADDR=10.96.69.126",
                "MABING0821_5744_EXPORTER_SVC_PORT_9125_TCP_ADDR=10.97.152.175",
                "AKHQ_PORT_28081_TCP_PORT=28081",
                "MABING0821_5744_MYSQL_REPLICAS_PORT_3306_TCP=tcp://10.99.64.183:3306",
                "MGR0325_PORT=tcp://10.96.69.126:3306",
                "MABING0821_5744_EXPORTER_SVC_PORT=tcp://10.97.152.175:9125",
                "MABING0821_5744_EXPORTER_SVC_SERVICE_HOST=10.97.152.175",
                "NOTEBOOK0822_PORT=tcp://10.103.75.165:80",
                "MGR0325_PORT_6447_TCP_ADDR=10.96.69.126",
                "MGR0325_PORT_8443_TCP_PORT=8443",
                "MABING0821_5744_MYSQL_SERVICE_PORT_MYSQL=3306",
                "KAFDROP_PORT_9000_TCP_ADDR=10.97.30.224",
                "MGR0325_PORT_6447_TCP_PROTO=tcp",
                "MABING0821_5744_EXPORTER_SVC_PORT_9125_TCP_PROTO=tcp",
                "MABING0821_5744_MYSQL_MASTER_PORT_8080_TCP_PROTO=tcp",
                "MGR0325_PORT_6450_TCP_PROTO=tcp",
                "AKHQ_PORT=tcp://10.111.64.47:80",
                "KINGBASE_V8R6_PORT_54321_TCP_PORT=54321",
                "NOTEBOOK0822_SERVICE_HOST=10.103.75.165",
                "MABING0821_5744_MYSQL_MASTER_SERVICE_HOST=10.111.105.70",
                "KINGBASE_V8R6_SERVICE_PORT=54321",
                "MABING0821_5744_MYSQL_REPLICAS_SERVICE_PORT_MYSQL=3306",
                "MABING0821_5744_MYSQL_REPLICAS_PORT_8080_TCP_PORT=8080",
                "KAFDROP_SERVICE_PORT=9000",
                "MGR0325_SERVICE_PORT_MYSQL_RO=6447",
                "MABING0821_5744_MYSQL_MASTER_SVC_PORT_3306_TCP=tcp://10.104.149.173:3306",
                "KUBERNETES_SERVICE_PORT_HTTPS=443",
                "KUBERNETES_PORT_443_TCP=tcp://10.96.0.1:443",
                "MGR0325_SERVICE_PORT_ROUTER_REST=8443",
                "MABING0821_5744_MYSQL_PORT_3306_TCP=tcp://10.96.164.154:3306",
                "MGR0325_SERVICE_PORT_MYSQLX_RO=6449",
                "MGR0325_PORT_33060_TCP_PORT=33060",
                "MGR0325_PORT_6448_TCP_PORT=6448",
                "AKHQ_SERVICE_PORT_HTTP=80",
                "KINGBASE_V8R6_PORT_54321_TCP=tcp://10.99.145.202:54321",
                "MGR0325_SERVICE_HOST=10.96.69.126",
                "MABING0821_5744_MYSQL_MASTER_PORT_3306_TCP_PORT=3306",
                "MABING0821_5744_MYSQL_MASTER_PORT_8080_TCP=tcp://10.111.105.70:8080",
                "MABING0821_5744_MYSQL_REPLICAS_SERVICE_HOST=10.99.64.183",
                "MGR0325_PORT_6446_TCP=tcp://10.96.69.126:6446",
                "AKHQ_SERVICE_PORT_MANAGEMENT=28081",
                "KINGBASE_V8R6_PORT_54321_TCP_PROTO=tcp",
                "KAFDROP_PORT=tcp://10.97.30.224:9000",
                "MABING0821_5744_MYSQL_MASTER_PORT_3306_TCP=tcp://10.111.105.70:3306",
                "MGR0325_PORT_6448_TCP=tcp://10.96.69.126:6448",
                "MABING0821_5744_MYSQL_MASTER_SVC_SERVICE_PORT_MYSQL=3306",
                "MGR0325_PORT_6447_TCP_PORT=6447",
                "MABING0821_5744_MYSQL_MASTER_SVC_PORT_3306_TCP_PROTO=tcp",
                "MABING0821_5744_MYSQL_MASTER_SVC_PORT_3306_TCP_ADDR=10.104.149.173",
                "MGR0325_SERVICE_PORT_MYSQL=3306",
                "MGR0325_PORT_6447_TCP=tcp://10.96.69.126:6447",
                "MABING0821_5744_MYSQL_MASTER_SERVICE_PORT_MYSQL=3306",
                "MABING0821_5744_MYSQL_MASTER_PORT=tcp://10.111.105.70:3306",
                "MABING0821_5744_MYSQL_MASTER_PORT_3306_TCP_PROTO=tcp",
                "MABING0821_5744_MYSQL_REPLICAS_PORT_3306_TCP_PROTO=tcp",
                "AKHQ_PORT_80_TCP_ADDR=10.111.64.47",
                "KAFDROP_PORT_9000_TCP_PROTO=tcp",
                "MABING0821_5744_MYSQL_MASTER_PORT_8080_TCP_PORT=8080",
                "KAFDROP_SERVICE_HOST=10.97.30.224",
                "MGR0325_SERVICE_PORT=3306",
                "MGR0325_PORT_6446_TCP_PORT=6446",
                "MGR0325_PORT_8443_TCP_ADDR=10.96.69.126",
                "PATH=/opt/conda/bin:/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin",
                "NB_USER=jovyan",
                "NB_UID=1000",
                "NB_GID=0",
                "HOME=/home/jovyan",
                "SHELL=/bin/bash",
                "USERS_GID=100",
                "HOME_TMP=/tmp_home/jovyan",
                "S6_CMD_WAIT_FOR_SERVICES_MAXTIME=300000",
                "S6_BEHAVIOUR_IF_STAGE2_FAILS=2",
                "LANG=en_US.UTF-8",
                "LANGUAGE=en_US.UTF-8",
                "LC_ALL=en_US.UTF-8",
                "CONDA_DIR=/opt/conda"
            ],
            "ExposedPorts": {
                "8888/tcp": {}
            },
            "Healthcheck": {
                "Test": [
                    "NONE"
                ]
            },
            "Hostname": "",
            "Image": "",
            "Labels": {
                "annotation.io.kubernetes.container.hash": "b4be2b46",
                "annotation.io.kubernetes.container.ports": "[{\"name\":\"notebook-port\",\"containerPort\":8888,\"protocol\":\"TCP\"}]",
                "annotation.io.kubernetes.container.preStopHandler": "{\"exec\":{\"command\":[\"sleep\",\"60\"]}}",
                "annotation.io.kubernetes.container.restartCount": "0",
                "annotation.io.kubernetes.container.terminationMessagePath": "/dev/termination-log",
                "annotation.io.kubernetes.container.terminationMessagePolicy": "File",
                "annotation.io.kubernetes.pod.terminationGracePeriod": "60",
                "io.kubernetes.container.logpath": "/var/log/pods/default_notebook0822-0_8dc37003-bdcc-45ab-a555-f65d704c1d30/notebook0822/0.log",
                "io.kubernetes.container.name": "notebook0822",
                "io.kubernetes.docker.type": "container",
                "io.kubernetes.pod.name": "notebook0822-0",
                "io.kubernetes.pod.namespace": "default",
                "io.kubernetes.pod.uid": "8dc37003-bdcc-45ab-a555-f65d704c1d30",
                "io.kubernetes.sandbox.id": "eaf6cfc03b58a1218b16de976fa37059576b697b0bb4d9d2f0bed044f7fdec6d",
                "org.opencontainers.image.ref.name": "ubuntu",
                "org.opencontainers.image.version": "22.04"
            },
            "OnBuild": null,
            "OpenStdin": false,
            "StdinOnce": false,
            "Tty": false,
            "User": "0",
            "Volumes": null,
            "WorkingDir": "/home/jovyan"
        }
    }
]
, errOut: , err: <nil>
I0826 03:11:01.774090       1 docker_compatible.go:97] execCommand: docker [login release-ci.daocloud.io], out: Authenticating with existing credentials...
Login Succeeded
, errOut: WARNING! Your password will be stored unencrypted in /tmp/.docker-config-2531445334/config.json.
Configure a credential helper to remove this warning. See
https://docs.docker.com/engine/reference/commandline/login/#credentials-store

, err: <nil>
I0826 03:12:32.426645       1 docker_compatible.go:97] execCommand: docker [push release-ci.daocloud.io/aichat/baize-notebook:snapped-1756177850-f096e326], out: The push refers to repository [release-ci.daocloud.io/aichat/baize-notebook]
8e5c0691c425: Preparing
a334d6bfa269: Preparing
b16d81b9c699: Preparing
1d70909daa7c: Preparing
fe22f0d183d5: Preparing
5c13a29d0f92: Preparing
5619ebf6d87a: Preparing
3e4ff3e3033e: Preparing
5876eee782f2: Preparing
20fa7b16bf50: Preparing
f85275666708: Preparing
14aee8924f85: Preparing
a2bd2ab2ae36: Preparing
df32b1b754a1: Preparing
5c13a29d0f92: Waiting
5619ebf6d87a: Waiting
20fa7b16bf50: Waiting
f85275666708: Waiting
5876eee782f2: Waiting
3e4ff3e3033e: Waiting
14aee8924f85: Waiting
a2bd2ab2ae36: Waiting
c4edf25bff52: Preparing
e2b0056708c4: Preparing
c4b0041ab583: Preparing
c2c2cbddab08: Preparing
df32b1b754a1: Waiting
81bf62d73125: Preparing
089daa7f475c: Preparing
0792c5b6dfde: Preparing
c4edf25bff52: Waiting
e4932670a4ca: Preparing
e2b0056708c4: Waiting
6dc41e67edf6: Preparing
c4b0041ab583: Waiting
c2c2cbddab08: Waiting
9fcf1aaa6291: Preparing
81bf62d73125: Waiting
089daa7f475c: Waiting
2fcc256d0e2c: Preparing
0792c5b6dfde: Waiting
6dc41e67edf6: Waiting
e4932670a4ca: Waiting
9fcf1aaa6291: Waiting
b313f5729b08: Preparing
e07f806fd33a: Preparing
9bc2ae963bba: Preparing
6d6f2e66c598: Preparing
49a532170928: Preparing
be4bc107e225: Preparing
2fcc256d0e2c: Waiting
2f16d2faf991: Preparing
b67fc286cf01: Preparing
0b6ce2602554: Preparing
b313f5729b08: Waiting
e07f806fd33a: Waiting
9bc2ae963bba: Waiting
6d6f2e66c598: Waiting
49a532170928: Waiting
2f16d2faf991: Waiting
be4bc107e225: Waiting
b67fc286cf01: Waiting
e63c814e86dc: Preparing
4e31776d15a9: Preparing
b139b771a667: Preparing
8c343de658a6: Preparing
048d77f5d0e8: Preparing
931b7ff0cb6f: Preparing
e63c814e86dc: Waiting
0b6ce2602554: Waiting
4e31776d15a9: Waiting
b139b771a667: Waiting
8c343de658a6: Waiting
048d77f5d0e8: Waiting
931b7ff0cb6f: Waiting
fe22f0d183d5: Mounted from baize/baize-notebook
a334d6bfa269: Mounted from baize/baize-notebook
b16d81b9c699: Mounted from baize/baize-notebook
1d70909daa7c: Mounted from baize/baize-notebook
5619ebf6d87a: Mounted from baize/baize-notebook
5c13a29d0f92: Mounted from baize/baize-notebook
3e4ff3e3033e: Mounted from baize/baize-notebook
20fa7b16bf50: Mounted from baize/baize-notebook
5876eee782f2: Mounted from baize/baize-notebook
f85275666708: Mounted from baize/baize-notebook
14aee8924f85: Mounted from baize/baize-notebook
a2bd2ab2ae36: Mounted from baize/baize-notebook
df32b1b754a1: Mounted from baize/baize-notebook
e2b0056708c4: Mounted from baize/baize-notebook
c4edf25bff52: Mounted from baize/baize-notebook
c4b0041ab583: Mounted from baize/baize-notebook
c2c2cbddab08: Mounted from baize/baize-notebook
81bf62d73125: Mounted from baize/baize-notebook
0792c5b6dfde: Mounted from baize/baize-notebook
089daa7f475c: Mounted from baize/baize-notebook
e4932670a4ca: Mounted from baize/baize-notebook
6dc41e67edf6: Mounted from baize/baize-notebook
2fcc256d0e2c: Mounted from baize/baize-notebook
b313f5729b08: Mounted from baize/baize-notebook
9fcf1aaa6291: Mounted from baize/baize-notebook
e07f806fd33a: Mounted from baize/baize-notebook
9bc2ae963bba: Mounted from baize/baize-notebook
6d6f2e66c598: Mounted from baize/baize-notebook
49a532170928: Mounted from baize/baize-notebook
be4bc107e225: Mounted from baize/baize-notebook
2f16d2faf991: Mounted from baize/baize-notebook
b67fc286cf01: Mounted from baize/baize-notebook
0b6ce2602554: Mounted from baize/baize-notebook
e63c814e86dc: Mounted from baize/baize-notebook
4e31776d15a9: Mounted from baize/baize-notebook
b139b771a667: Mounted from baize/baize-notebook
8c343de658a6: Mounted from baize/baize-notebook
048d77f5d0e8: Mounted from baize/baize-notebook
931b7ff0cb6f: Mounted from baize/baize-notebook
8e5c0691c425: Pushed
snapped-1756177850-f096e326: digest: sha256:2a75ab982bf89be04c2a634fe04db32962777a72de881d684caabf8883034c04 size: 8714
, errOut: , err: <nil>
```

