### PR TITLE
fix: update image tools for CVEs

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -29,8 +29,8 @@ RUN CGO_ENABLED=0 GOOS=${TARGETOS:-linux} GOARCH=${TARGETARCH} go build -a -o ma
 FROM docker.io/ubuntu:22.04
 WORKDIR /
 
-ENV DOCKER_VERSION=26.1.3
-ENV NERDCTL_VERSION=2.1.2
+ENV DOCKER_VERSION=29.3.1
+ENV NERDCTL_VERSION=2.3.2
 
 RUN apt-get update && apt-get install -y curl && apt-get clean && \
     curl -fsSL https://download.docker.com/linux/static/stable/$(uname -m)/docker-${DOCKER_VERSION}.tgz | tar -xzC /usr/local/bin --strip-components=1 docker/docker && \


### PR DESCRIPTION
## Summary

Update the tools embedded in the snapshot-controller image:

- Docker CLI: `26.1.3` -> `29.3.1`
- nerdctl: `2.1.2` -> `2.3.2`

The Trivy  reported CRITICAL findings from the bundled `docker` and `nerdctl` binaries. This change updates those external tools so the image no longer carries those CRITICAL gobinary findings.

## Validation

- `go test ./api/... ./cmd/... ./internal/controller/runtime ./internal/metrics ./internal/webhooks ./pkg/...`
- `git diff --check`
- Downloaded Docker `29.3.1` and nerdctl `2.3.2`, built a scratch verification image containing only `/usr/local/bin/docker` and `/usr/local/bin/nerdctl`, then scanned with Trivy:
  - `usr/local/bin/docker`: 0 CRITICAL
  - `usr/local/bin/nerdctl`: 0 CRITICAL

`go test ./...` was not usable in this sandbox because envtest needs local socket binding and e2e needs cluster/network access.